### PR TITLE
Update docs about pipeline variables now available in production

### DIFF
--- a/docs/pipeline_variables_overview.md
+++ b/docs/pipeline_variables_overview.md
@@ -16,4 +16,15 @@ jobs:
     ...
 ```
 
+
+And here's how you can get the `CIRCLE_COMPARE_URL` in v2.1:
+
+```
+version: 2.1
+jobs:
+  my-job:
+    environment:
+      CIRCLE_COMPARE_URL: << pipeline.project.git_url >>/compare/<< pipeline.git.base_revision >>..<<pipeline.git.revision>>
+```
+
 Next step: review [the list of available pipeline variables](pipeline_variables_reference.md)

--- a/docs/pipeline_variables_reference.md
+++ b/docs/pipeline_variables_reference.md
@@ -9,40 +9,42 @@ If a value isn't available it will resolve to an empty string during config expa
 (THIS LIST IS UNDER DESIGN - FEEDBACK WELCOMED.)
 
 First batch:
-```
-pipeline.id
-pipeline.number
-pipeline.project.name
-pipeline.project.git_url
-pipeline.project.type _or_ pipeline.project.source
 
-pipeline.trigger.tag
-pipeline.trigger.branch
-pipeline.trigger.revision
-pipeline.trigger.base_revision
-```
+- `pipeline.id` - a *globally* unique id representing the pipeline
+- `pipeline.number` - a *project* unique integer id for the pipeline
+- `pipeline.project.git_url` - e.g. https://github.com/circleci/circleci-docs
+- `pipeline.project.type` - e.g. "github"
+- `pipeline.git.tag` - the tag triggering the pipeline
+- `pipeline.git.branch` - the branch triggering the pipeline
+- `pipeline.git.revision` - the current git revision
+- `pipeline.git.base_revision` - the *previous* git revision
+
 
 Second batch:
-```
-pipeline.project_slug
-pipeline.created_timestamp
-pipeline.trigger.rerun_of
-pipeline.trigger.actor
-```
+
+- `pipeline.project.name`
+- `pipeline.project_slug`
+- `pipeline.created_timestamp`
+- `pipeline.trigger.rerun_of`
+- `pipeline.trigger.actor`
+
 
 Other potential variables:
-```
-pipeline.pull_request.draft (boolean)
-pipeline.pull_request.number
-pipeline.pull_request.url
-pipeline.pull_request.source_branch
-pipeline.pull_request.source_repo
-pipeline.pull_request.target_branch
-pipeline.pull_request.target_repo
-pipeline.pull_request.fork (boolean - useful, or should we prefer comparing source/target?)
 
-pipeline.project.default_branch
-pipeline.project.organization_name
+- `pipeline.pull_request.draft` (boolean)
+- `pipeline.pull_request.number`
+- `pipeline.pull_request.url`
+- `pipeline.pull_request.source_branch`
+- `pipeline.pull_request.source_repo`
+- `pipeline.pull_request.target_branch`
+- `pipeline.pull_request.target_repo`
+- `pipeline.pull_request.fork` (boolean - useful, or should we prefer comparing source/target?)
 
-(Speculative): pipeline.project.settings.*
-```
+- `pipeline.project.default_branch`
+- `pipeline.project.organization_name`
+
+
+(Speculative):
+
+- `pipeline.project.settings.*`
+


### PR DESCRIPTION
Reflect the first set of pipeline variables available in production.

~The last commit is a rename from "Pipeline Variables" to "Pipeline Values", simply because that's what we're calling them in the code. (And they don't vary: they're constants. Um, maybe Pipeline constants would also work?) Anyway, if you don't like that rename I'm happy to revert that particular change.~